### PR TITLE
Update to version 2.0.0 with breaking changes: Result now returns a d…

### DIFF
--- a/Frends.Snowflake.ExecuteQuery/CHANGELOG.md
+++ b/Frends.Snowflake.ExecuteQuery/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [2.0.0] - 2025-09-03
+### Changed
+- [Breaking] Result now returns a dynamic JToken instead of DataTable when using ExecuteReader mode.
+- Added support for CancellationToken, thus enabling query cancellation.
+
 ## [1.2.0] - 2025-09-03
 ### Added
   - Added support for Snowflake key pair authentication:

--- a/Frends.Snowflake.ExecuteQuery/Frends.Snowflake.ExecuteQuery.Test/UnitTests.cs
+++ b/Frends.Snowflake.ExecuteQuery/Frends.Snowflake.ExecuteQuery.Test/UnitTests.cs
@@ -3,8 +3,9 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Snowflake.Data.Client;
 using System;
 using System.Collections.Generic;
-using System.Data;
 using System.IO;
+using System.Threading;
+using Newtonsoft.Json.Linq;
 
 namespace Frends.Snowflake.ExecuteQuery.Tests;
 
@@ -76,7 +77,7 @@ public class UnitTests
     {
         _input.CommandText = @$"insert into TaskTestTable values ('{_names[_random.Next(_names.Count)]}', 10);";
         _input.CommandType = CommandTypes.ExecuteReader;
-        var result = Snowflake.ExecuteQuery(_input, _options);
+        var result = Snowflake.ExecuteQuery(_input, _options, CancellationToken.None);
         Assert.IsTrue(result.Success);
         Assert.AreEqual(1, result.RecordsAffected);
         Assert.IsNull(result.ErrorMessage);
@@ -87,7 +88,7 @@ public class UnitTests
     {
         _input.CommandText = @$"insert into TaskTestTable values ('{_names[_random.Next(_names.Count)]}', 20);";
         _input.CommandType = CommandTypes.ExecuteNonQuery;
-        var result = Snowflake.ExecuteQuery(_input, _options);
+        var result = Snowflake.ExecuteQuery(_input, _options, CancellationToken.None);
         Assert.IsTrue(result.Success);
         Assert.IsNull(result.Data);
         Assert.IsNull(result.ErrorMessage);
@@ -98,7 +99,7 @@ public class UnitTests
     {
         _input.CommandText = @$"insert into TaskTestTable values ('{_names[_random.Next(_names.Count)]}', 30);";
         _input.CommandType = CommandTypes.ExecuteScalar;
-        var result = Snowflake.ExecuteQuery(_input, _options);
+        var result = Snowflake.ExecuteQuery(_input, _options, CancellationToken.None);
         Assert.IsTrue(result.Success);
         Assert.IsNotNull(result.Data);
         Assert.IsNull(result.ErrorMessage);
@@ -109,7 +110,7 @@ public class UnitTests
     {
         _input.CommandText = "insert into NoTable values ('A', 1);";
         _input.CommandType = CommandTypes.ExecuteReader;
-        Assert.ThrowsException<SnowflakeDbException>(() => Snowflake.ExecuteQuery(_input, _options));
+        Assert.ThrowsException<SnowflakeDbException>(() => Snowflake.ExecuteQuery(_input, _options, CancellationToken.None));
     }
 
     [TestMethod]
@@ -118,7 +119,7 @@ public class UnitTests
         _input.CommandText = "insert into NoTable values ('A', 1);";
         _input.CommandType = CommandTypes.ExecuteReader;
         _options.ThrowExceptionOnError = false;
-        var result = Snowflake.ExecuteQuery(_input, _options);
+        var result = Snowflake.ExecuteQuery(_input, _options, CancellationToken.None);
         Assert.IsFalse(result.Success);
         Assert.IsNull(result.Data);
         Assert.IsTrue(result.ErrorMessage.Message.Contains("Table 'NOTABLE' does not exist or not authorized"));
@@ -129,7 +130,7 @@ public class UnitTests
     {
         _input.CommandText = "insert into NoTable values ('A', 1);";
         _input.CommandType = CommandTypes.ExecuteNonQuery;
-        Assert.ThrowsException<SnowflakeDbException>(() => Snowflake.ExecuteQuery(_input, _options));
+        Assert.ThrowsException<SnowflakeDbException>(() => Snowflake.ExecuteQuery(_input, _options, CancellationToken.None));
     }
 
     [TestMethod]
@@ -138,7 +139,7 @@ public class UnitTests
         _input.CommandText = "insert into NoTable values ('A', 1);";
         _input.CommandType = CommandTypes.ExecuteNonQuery;
         _options.ThrowExceptionOnError = false;
-        var result = Snowflake.ExecuteQuery(_input, _options);
+        var result = Snowflake.ExecuteQuery(_input, _options, CancellationToken.None);
         Assert.IsFalse(result.Success);
         Assert.IsNull(result.Data);
         Assert.IsTrue(result.ErrorMessage.Message.Contains("Table 'NOTABLE' does not exist or not authorized"));
@@ -149,7 +150,7 @@ public class UnitTests
     {
         _input.CommandText = "insert into NoTable values ('A', 1);";
         _input.CommandType = CommandTypes.ExecuteScalar;
-        Assert.ThrowsException<SnowflakeDbException>(() => Snowflake.ExecuteQuery(_input, _options));
+        Assert.ThrowsException<SnowflakeDbException>(() => Snowflake.ExecuteQuery(_input, _options, CancellationToken.None));
     }
 
     [TestMethod]
@@ -158,7 +159,7 @@ public class UnitTests
         _input.CommandText = "insert into NoTable values ('A', 1);";
         _input.CommandType = CommandTypes.ExecuteScalar;
         _options.ThrowExceptionOnError = false;
-        var result = Snowflake.ExecuteQuery(_input, _options);
+        var result = Snowflake.ExecuteQuery(_input, _options, CancellationToken.None);
         Assert.IsFalse(result.Success);
         Assert.IsNull(result.Data);
         Assert.IsTrue(result.ErrorMessage.Message.Contains("Table 'NOTABLE' does not exist or not authorized"));
@@ -169,7 +170,7 @@ public class UnitTests
     {
         _input.CommandText = "insert into TaskTestTable values (1, 'A');";
         _input.CommandType = CommandTypes.ExecuteReader;
-        Assert.ThrowsException<SnowflakeDbException>(() => Snowflake.ExecuteQuery(_input, _options));
+        Assert.ThrowsException<SnowflakeDbException>(() => Snowflake.ExecuteQuery(_input, _options, CancellationToken.None));
     }
 
     [TestMethod]
@@ -178,7 +179,7 @@ public class UnitTests
         _input.CommandText = "insert into TaskTestTable values (1, 'A');";
         _input.CommandType = CommandTypes.ExecuteReader;
         _options.ThrowExceptionOnError = false;
-        var result = Snowflake.ExecuteQuery(_input, _options);
+        var result = Snowflake.ExecuteQuery(_input, _options, CancellationToken.None);
         Assert.IsFalse(result.Success);
         Assert.IsNull(result.Data);
         Assert.IsTrue(result.ErrorMessage.Message.Contains("Numeric value 'A' is not recognized"));
@@ -189,7 +190,7 @@ public class UnitTests
     {
         _input.CommandText = "insert into TaskTestTable values (1, 'A');";
         _input.CommandType = CommandTypes.ExecuteNonQuery;
-        Assert.ThrowsException<SnowflakeDbException>(() => Snowflake.ExecuteQuery(_input, _options));
+        Assert.ThrowsException<SnowflakeDbException>(() => Snowflake.ExecuteQuery(_input, _options, CancellationToken.None));
     }
 
     [TestMethod]
@@ -198,7 +199,7 @@ public class UnitTests
         _input.CommandText = "insert into TaskTestTable values (1, 'A');";
         _input.CommandType = CommandTypes.ExecuteNonQuery;
         _options.ThrowExceptionOnError = false;
-        var result = Snowflake.ExecuteQuery(_input, _options);
+        var result = Snowflake.ExecuteQuery(_input, _options, CancellationToken.None);
         Assert.IsFalse(result.Success);
         Assert.IsNull(result.Data);
         Assert.IsTrue(result.ErrorMessage.Message.Contains("Numeric value 'A' is not recognized"));
@@ -209,7 +210,7 @@ public class UnitTests
     {
         _input.CommandText = "insert into TaskTestTable values (1, 'A');";
         _input.CommandType = CommandTypes.ExecuteScalar;
-        Assert.ThrowsException<SnowflakeDbException>(() => Snowflake.ExecuteQuery(_input, _options));
+        Assert.ThrowsException<SnowflakeDbException>(() => Snowflake.ExecuteQuery(_input, _options, CancellationToken.None));
     }
 
     [TestMethod]
@@ -218,7 +219,7 @@ public class UnitTests
         _input.CommandText = "insert into TaskTestTable values (1, 'A');";
         _input.CommandType = CommandTypes.ExecuteScalar;
         _options.ThrowExceptionOnError = false;
-        var result = Snowflake.ExecuteQuery(_input, _options);
+        var result = Snowflake.ExecuteQuery(_input, _options, CancellationToken.None);
         Assert.IsFalse(result.Success);
         Assert.IsNull(result.Data);
         Assert.IsTrue(result.ErrorMessage.Message.Contains("Numeric value 'A' is not recognized"));
@@ -229,11 +230,19 @@ public class UnitTests
     {
         _input.CommandText = "Select * from TaskTestTable;";
         _input.CommandType = CommandTypes.ExecuteReader;
-        var result = Snowflake.ExecuteQuery(_input, _options);
+        var result = Snowflake.ExecuteQuery(_input, _options, CancellationToken.None);
         Assert.IsTrue(result.Success);
-        Assert.IsTrue(result.Data.Rows.Count > 0);
+        Assert.IsTrue(result.Data.Count > 0);
         Assert.IsNull(result.ErrorMessage);
         Assert.AreEqual(-1, result.RecordsAffected);
+
+        // Check props
+        var jObject = (JObject)result.Data[0];
+        Assert.IsTrue(jObject.ContainsKey("NAME"));
+        Assert.IsTrue(jObject.ContainsKey("AGE"));
+        Assert.AreEqual(2, jObject.Count);
+        Assert.IsTrue(!string.IsNullOrWhiteSpace((string)jObject["NAME"]!));
+        Assert.IsTrue((int)jObject["AGE"]! > 0);
     }
 
     [TestMethod]
@@ -241,7 +250,7 @@ public class UnitTests
     {
         _input.CommandText = "Select * from TaskTestTable;";
         _input.CommandType = CommandTypes.ExecuteNonQuery;
-        var result = Snowflake.ExecuteQuery(_input, _options);
+        var result = Snowflake.ExecuteQuery(_input, _options, CancellationToken.None);
         Assert.IsTrue(result.Success);
         Assert.IsNull(result.Data);
         Assert.IsNull(result.ErrorMessage);
@@ -253,7 +262,7 @@ public class UnitTests
     {
         _input.CommandText = "Select * from TaskTestTable;";
         _input.CommandType = CommandTypes.ExecuteScalar;
-        var result = Snowflake.ExecuteQuery(_input, _options);
+        var result = Snowflake.ExecuteQuery(_input, _options, CancellationToken.None);
         Assert.IsTrue(result.Success);
         Assert.IsTrue(_names.Contains(result.Data.Value.ToString()));
         Assert.IsNull(result.ErrorMessage);
@@ -265,7 +274,7 @@ public class UnitTests
     {
         _input.CommandText = "update TaskTestTable set age = 'B' where name = 10;";
         _input.CommandType = CommandTypes.ExecuteReader;
-        Assert.ThrowsException<SnowflakeDbException>(() => Snowflake.ExecuteQuery(_input, _options));
+        Assert.ThrowsException<SnowflakeDbException>(() => Snowflake.ExecuteQuery(_input, _options, CancellationToken.None));
     }
 
     [TestMethod]
@@ -274,7 +283,7 @@ public class UnitTests
         _input.CommandText = "update TaskTestTable set age = 'B' where name = 10;";
         _input.CommandType = CommandTypes.ExecuteReader;
         _options.ThrowExceptionOnError = false;
-        var result = Snowflake.ExecuteQuery(_input, _options);
+        var result = Snowflake.ExecuteQuery(_input, _options, CancellationToken.None);
         Assert.IsFalse(result.Success);
         Assert.IsNull(result.Data);
         Assert.IsTrue(result.ErrorMessage.Message.Contains("is not recognized SqlState: 22018"));
@@ -285,7 +294,7 @@ public class UnitTests
     {
         _input.CommandText = "update TaskTestTable set age = 'B' where name = 10;";
         _input.CommandType = CommandTypes.ExecuteNonQuery;
-        Assert.ThrowsException<SnowflakeDbException>(() => Snowflake.ExecuteQuery(_input, _options));
+        Assert.ThrowsException<SnowflakeDbException>(() => Snowflake.ExecuteQuery(_input, _options, CancellationToken.None));
     }
 
     [TestMethod]
@@ -294,7 +303,7 @@ public class UnitTests
         _input.CommandText = "update TaskTestTable set age = 'B' where name = 10;";
         _input.CommandType = CommandTypes.ExecuteNonQuery;
         _options.ThrowExceptionOnError = false;
-        var result = Snowflake.ExecuteQuery(_input, _options);
+        var result = Snowflake.ExecuteQuery(_input, _options, CancellationToken.None);
         Assert.IsFalse(result.Success);
         Assert.IsNull(result.Data);
         Assert.IsTrue(result.ErrorMessage.Message.Contains("is not recognized SqlState: 22018"));
@@ -305,7 +314,7 @@ public class UnitTests
     {
         _input.CommandText = "update TaskTestTable set age = 'B' where name = 10;";
         _input.CommandType = CommandTypes.ExecuteNonQuery;
-        Assert.ThrowsException<SnowflakeDbException>(() => Snowflake.ExecuteQuery(_input, _options));
+        Assert.ThrowsException<SnowflakeDbException>(() => Snowflake.ExecuteQuery(_input, _options, CancellationToken.None));
     }
 
     [TestMethod]
@@ -314,7 +323,7 @@ public class UnitTests
         _input.CommandText = "update TaskTestTable set age = 'B' where name = 10;";
         _input.CommandType = CommandTypes.ExecuteScalar;
         _options.ThrowExceptionOnError = false;
-        var result = Snowflake.ExecuteQuery(_input, _options);
+        var result = Snowflake.ExecuteQuery(_input, _options, CancellationToken.None);
         Assert.IsFalse(result.Success);
         Assert.IsNull(result.Data);
         Assert.IsTrue(result.ErrorMessage.Message.Contains("is not recognized SqlState: 22018"));
@@ -325,14 +334,14 @@ public class UnitTests
     {
         _input.CommandText = "update TaskTestTable set age = 21 where age = 20;";
         _input.CommandType = CommandTypes.ExecuteReader;
-        var result = Snowflake.ExecuteQuery(_input, _options);
+        var result = Snowflake.ExecuteQuery(_input, _options, CancellationToken.None);
         Assert.IsTrue(result.Success);
         Assert.IsTrue(result.RecordsAffected > 0);
 
         // restore
         _input.CommandText = "update TaskTestTable set age = 20 where age = 21;";
         _input.CommandType = CommandTypes.ExecuteNonQuery;
-        Snowflake.ExecuteQuery(_input, _options);
+        Snowflake.ExecuteQuery(_input, _options, CancellationToken.None);
     }
 
     [TestMethod]
@@ -340,14 +349,14 @@ public class UnitTests
     {
         _input.CommandText = "update TaskTestTable set age = 31 where age = 30;";
         _input.CommandType = CommandTypes.ExecuteNonQuery;
-        var result = Snowflake.ExecuteQuery(_input, _options);
+        var result = Snowflake.ExecuteQuery(_input, _options, CancellationToken.None);
         Assert.IsTrue(result.Success);
         Assert.IsTrue(result.RecordsAffected > 0);
 
         // restore
         _input.CommandText = "update TaskTestTable set age = 30 where age = 31;";
         _input.CommandType = CommandTypes.ExecuteNonQuery;
-        Snowflake.ExecuteQuery(_input, _options);
+        Snowflake.ExecuteQuery(_input, _options, CancellationToken.None);
     }
 
     [TestMethod]
@@ -355,7 +364,7 @@ public class UnitTests
     {
         _input.CommandText = "update TaskTestTable set age = 11 where age = 10;";
         _input.CommandType = CommandTypes.ExecuteScalar;
-        var result = Snowflake.ExecuteQuery(_input, _options);
+        var result = Snowflake.ExecuteQuery(_input, _options, CancellationToken.None);
         Assert.IsTrue(result.Success);
         Assert.IsTrue(result.Data.Value > 0);
         Assert.IsTrue(result.RecordsAffected > 0);
@@ -363,28 +372,28 @@ public class UnitTests
         // restore
         _input.CommandText = "update TaskTestTable set age = 10 where age = 11;";
         _input.CommandType = CommandTypes.ExecuteNonQuery;
-        Snowflake.ExecuteQuery(_input, _options);
+        Snowflake.ExecuteQuery(_input, _options, CancellationToken.None);
     }
 
     [TestMethod]
     public void ExecuteTest_InvalidConnectionString_IsNULL()
     {
         _input.ConnectionString = null;
-        Assert.ThrowsException<Exception>(() => Snowflake.ExecuteQuery(_input, _options));
+        Assert.ThrowsException<Exception>(() => Snowflake.ExecuteQuery(_input, _options, CancellationToken.None));
     }
 
     [TestMethod]
     public void ExecuteTest_InvalidConnectionString_Empty()
     {
         _input.ConnectionString = "";
-        Assert.ThrowsException<Exception>(() => Snowflake.ExecuteQuery(_input, _options));
+        Assert.ThrowsException<Exception>(() => Snowflake.ExecuteQuery(_input, _options, CancellationToken.None));
     }
 
     [TestMethod]
     public void ExecuteTest_InvalidConnectionString_Foo_ThrowExceptionOnError_True()
     {
         _input.ConnectionString = "foo";
-        Assert.ThrowsException<ArgumentException>(() => Snowflake.ExecuteQuery(_input, _options));
+        Assert.ThrowsException<ArgumentException>(() => Snowflake.ExecuteQuery(_input, _options, CancellationToken.None));
     }
 
     [TestMethod]
@@ -392,7 +401,7 @@ public class UnitTests
     {
         _input.ConnectionString = "foo";
         _options.ThrowExceptionOnError = false;
-        var result = Snowflake.ExecuteQuery(_input, _options);
+        var result = Snowflake.ExecuteQuery(_input, _options, CancellationToken.None);
         Assert.IsFalse(result.Success);
         Assert.IsNull(result.Data);
         Assert.IsTrue(result.ErrorMessage.Message.Contains("Format of the initialization string does not conform to specification"));
@@ -403,7 +412,7 @@ public class UnitTests
     {
         _input.CommandText = "SELECT CURRENT_USER;";
         _input.CommandType = CommandTypes.ExecuteScalar;
-        var result = Snowflake.ExecuteQuery(_input, _options);
+        var result = Snowflake.ExecuteQuery(_input, _options, CancellationToken.None);
 
         Assert.IsTrue(result.Success);
         Assert.IsNotNull(result.Data);
@@ -417,7 +426,7 @@ public class UnitTests
         _input.PrivateKeyFilePath = "non_existing_key_file.p8";
         _options.ThrowExceptionOnError = false;
 
-        var result = Snowflake.ExecuteQuery(_input, _options);
+        var result = Snowflake.ExecuteQuery(_input, _options, CancellationToken.None);
 
         Assert.IsFalse(result.Success);
         Assert.IsNull(result.Data);
@@ -430,7 +439,7 @@ public class UnitTests
         _input.PrivateKeyPassphrase = "WrongPassphrase";
         _options.ThrowExceptionOnError = false;
 
-        var result = Snowflake.ExecuteQuery(_input, _options);
+        var result = Snowflake.ExecuteQuery(_input, _options, CancellationToken.None);
 
         Assert.IsFalse(result.Success);
         Assert.IsNull(result.Data);

--- a/Frends.Snowflake.ExecuteQuery/Frends.Snowflake.ExecuteQuery/Frends.Snowflake.ExecuteQuery.cs
+++ b/Frends.Snowflake.ExecuteQuery/Frends.Snowflake.ExecuteQuery/Frends.Snowflake.ExecuteQuery.cs
@@ -155,20 +155,6 @@ public class Snowflake
         return table;
     }
 
-    private static bool LooksLikeJson(string s)
-    {
-        // Cheap pre-check to avoid exceptions for normal strings
-        s = s.Trim();
-        return (s.Length > 1 && (s[0] == '{' && s[^1] == '}')) ||
-               (s.Length > 1 && (s[0] == '[' && s[^1] == ']'));
-    }
-
-    private static bool TryParseJson(string s, out JToken? token)
-    {
-        try { token = JToken.Parse(s); return true; }
-        catch { token = null; return false; }
-    }
-
     private static JToken FloatToJsonToken(double d)
     {
         if (double.IsNaN(d) || double.IsInfinity(d))

--- a/Frends.Snowflake.ExecuteQuery/Frends.Snowflake.ExecuteQuery/Frends.Snowflake.ExecuteQuery.cs
+++ b/Frends.Snowflake.ExecuteQuery/Frends.Snowflake.ExecuteQuery/Frends.Snowflake.ExecuteQuery.cs
@@ -8,6 +8,8 @@ using System.Data.Common;
 using System.IO;
 using System.Security.Cryptography;
 using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace Frends.Snowflake.ExecuteQuery;
 
@@ -23,7 +25,7 @@ public class Snowflake
     /// <param name="input">Connection and command parameters.</param>
     /// <param name="options">Options for controlling the behavior of a Task.</param>
     /// <returns>Object { bool Success, int RecordsAffected, dynamic ErrorMessage, dynamic Data }</returns>
-    public static Result ExecuteQuery([PropertyTab] Input input, [PropertyTab] Options options)
+    public static Result ExecuteQuery([PropertyTab] Input input, [PropertyTab] Options options, CancellationToken cancellationToken)
     {
         if (string.IsNullOrWhiteSpace(input.ConnectionString))
             throw new Exception("Invalid connection string.");
@@ -57,10 +59,9 @@ public class Snowflake
                     var executeNQ = cmd.ExecuteNonQuery();
                     return new Result(true, executeNQ, null, null);
                 case CommandTypes.ExecuteReader:
-                    var table = new DataTable();
                     var reader = cmd.ExecuteReader();
-                    table.Load(reader);
-                    var result = new Result(true, reader.RecordsAffected, null, table);
+                    var jToken = LoadData(reader, cancellationToken);
+                    var result = new Result(true, reader.RecordsAffected, null, jToken);
                     if (!reader.IsClosed)
                         reader.Close();
                     reader.Dispose();
@@ -79,5 +80,99 @@ public class Snowflake
                 throw;
             return new Result(false, 0, ex, null);
         }
+    }
+
+    private static JToken LoadData(IDataReader reader, CancellationToken cancellationToken)
+    {
+        var table = new JArray();
+
+        // Cache metadata up-front
+        var fieldCount = reader.FieldCount;
+        var names = new string[fieldCount];
+
+        for (var i = 0; i < fieldCount; i++)
+        {
+            names[i] = reader.GetName(i);
+        }
+
+        while (reader.Read())
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var row = new JObject();
+
+            for (var i = 0; i < fieldCount; i++)
+            {
+                object o = reader.GetValue(i);
+
+                JToken token;
+                if (o == DBNull.Value)
+                {
+                    token = JValue.CreateNull();
+                }
+                else if (o is byte[] bytes)
+                {
+                    // Snowflake BINARY -> base64 string is the most interoperable representation
+                    token = new JValue(Convert.ToBase64String(bytes));
+                }
+                else if (o is float f)
+                {
+                    token = FloatToJsonToken(f);
+                }
+                else if (o is double d)
+                {
+                    token = FloatToJsonToken(d);
+                }
+                else if (o is decimal m)
+                {
+                    // decimals are safe
+                    token = new JValue(m);
+                }
+                else if (o is DateTimeOffset dto)
+                {
+                    // Keep offset — JSON.NET will emit ISO 8601 with offset
+                    token = new JValue(dto);
+                }
+                else if (o is DateTime dt)
+                {
+                    token = new JValue(dt);
+                }
+                else if (o is string s)
+                {
+                    token = new JValue(s);
+                }
+                else
+                {
+                    token = JToken.FromObject(o);
+                }
+
+                row.Add(new JProperty(names[i], token));
+            }
+
+            table.Add(row);
+        }
+
+        return table;
+    }
+
+    private static bool LooksLikeJson(string s)
+    {
+        // Cheap pre-check to avoid exceptions for normal strings
+        s = s.Trim();
+        return (s.Length > 1 && (s[0] == '{' && s[^1] == '}')) ||
+               (s.Length > 1 && (s[0] == '[' && s[^1] == ']'));
+    }
+
+    private static bool TryParseJson(string s, out JToken? token)
+    {
+        try { token = JToken.Parse(s); return true; }
+        catch { token = null; return false; }
+    }
+
+    private static JToken FloatToJsonToken(double d)
+    {
+        if (double.IsNaN(d) || double.IsInfinity(d))
+            return JValue.CreateNull(); // or new JValue(d.ToString()) if you prefer strings
+        return new JValue(d);
     }
 }

--- a/Frends.Snowflake.ExecuteQuery/Frends.Snowflake.ExecuteQuery/Frends.Snowflake.ExecuteQuery.csproj
+++ b/Frends.Snowflake.ExecuteQuery/Frends.Snowflake.ExecuteQuery/Frends.Snowflake.ExecuteQuery.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
 	<TargetFrameworks>net6.0</TargetFrameworks>
-	<Version>1.2.0</Version>
+	<Version>2.0.0</Version>
 	<Authors>Frends</Authors>
 	<Copyright>Frends</Copyright>
 	<Company>Frends</Company>


### PR DESCRIPTION
…ynamic JToken instead of DataTable in ExecuteReader mode and added CancellationToken support for query cancellation.

[]# Frends Task Pull Request

## Summary
<!-- Brief description of changes -->

## Review Checklist

### 1. Frends Task Project Files
- Path: `Frends.*/Frends.*/*.csproj`
- [ ] Targets .NET 8
- [ ] Uses MIT license (`<PackageLicenseExpression>MIT</PackageLicenseExpression>`)
- [ ] Contains required fields:
  - [ ] `<Version>`
  - [ ] `<Authors>Frends</Authors>`
  - [ ] `<Description>`
  - [ ] `<RepositoryUrl>`
  - [ ] `<GenerateDocumentationFile>true</GenerateDocumentationFile>`

### 2. File: FrendsTaskMetadata.json
- [ ] Present: `Frends.*/Frends.*/FrendsTaskMetadata.json`
- [ ] FrendsTaskMetadata.json contains correct task method reference
- [ ] FrendsTaskMetadata.json is included in the project nuget package with path = "/"

### 3. File: README.md
- [ ] Present: `Frends.*/README.md`
- [ ] Contains badges (build, license, coverage)
- [ ] Includes developer setup instructions
- [ ] Does not include parameter descriptions

### 4. File: CHANGELOG.md
- [ ] Present: `Frends.*/CHANGELOG.md`
- [ ] Includes all functional changes
- [ ] Indicates breaking changes with upgrade notes
- [ ] Avoids non-functional notes like "refactored xyz"
- [ ] CHANGELOG.md is included in the project nuget package with path = "/"

### 5. File: migration.json
- [ ] Present: `Frends.*/Frends.*/migration.json`
- [ ] Contains breaking change migration information for Frends, if breaking changes exist
- [ ] migration.json is included in the project nuget package with path = "/"

### 6. Source Code Documentation
- Path: `Frends.*/Frends.*/*.cs`
- [ ] Every public method and class has:
  - [ ] `<summary>` XML comments
  - [ ] `<example>` XML comments
  - [ ] Optionally `<frendsdocs>` XML comments, if needed
- [ ] Follows Microsoft C# code conventions
- [ ] Uses semantic task result documentation (Success, Error, Data)

### 7. GitHub Actions Workflows
- Path: `.github/workflows/*.yml`
- [ ] Task has required workflow files:
  - [ ] `*_test.yml`
  - [ ] `*_main.yml`
  - [ ] `*_release.yml`
- [ ] Correct workdir pointing to task folder
- [ ] Docker setup included if task depends on external system (docker-compose.yml)

### 8. Task Result Object Structure
- Path: `Frends.*/Frends.*/*.cs`
- [ ] Category attribute is present, if applicable
- [ ] All task result classes include:
  - [ ] `Success` (bool)
  - [ ] Task-specific return value (e.g., Data, FilePaths), if needed
  - [ ] Error object with Message and AdditionalInfo
- [ ] Result structure is flat and simple
- [ ] Does not use 3rd-party types
- [ ] Uses dynamic JToken only when structure is unknown


---

## Additional Notes
<!-- Any additional information for reviewers -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Added cancellation support for queries via CancellationToken.
* Refactor
  * Breaking: ExecuteReader results now return JSON (dynamic JToken) instead of a DataTable.
  * Breaking: Public API now requires a CancellationToken parameter.
* Tests
  * Updated unit tests to validate JSON-based results and new API signature.
* Documentation
  * Changelog updated with 2.0.0 details, including breaking changes and cancellation support.
* Chores
  * Version bumped to 2.0.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->